### PR TITLE
Use exiftool/ImageSize for determining image width and height

### DIFF
--- a/xml/exiftool/exiftool_image_to_fits.xslt
+++ b/xml/exiftool/exiftool_image_to_fits.xslt
@@ -43,7 +43,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 						<xsl:value-of select="exiftool/ExifImageWidth[last()]"/>
 					</xsl:when>
 					<xsl:otherwise>
-						<xsl:value-of select="exiftool/ImageWidth[last()]"/>	
+						<xsl:value-of select="substring-before(exiftool/ImageSize, 'x')"/>	
 					</xsl:otherwise>
 				</xsl:choose>
 			</imageWidth>
@@ -53,7 +53,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 						<xsl:value-of select="exiftool/ExifImageHeight[last()]"/>
 					</xsl:when>
 					<xsl:otherwise>
-						<xsl:value-of select="exiftool/ImageHeight[last()]"/>	
+						<xsl:value-of select="substring-after(exiftool/ImageSize, 'x')"/>	
 					</xsl:otherwise>
 				</xsl:choose>
 			</imageHeight>


### PR DESCRIPTION
Pyramidal tiffs will report multiple values for exiftool/ImageWidth and exiftool/ImageHeight since FITS calls exiftool with the `-a` option and they have multiple image layers contained within the file.  For some files the last reported values could be a layer with different dimensions than the original image which leads to CONFLICT statuses with jhove.  exiftool/ImageSize only appears once in the exiftool output and its value matches the output from jhove.